### PR TITLE
Support non-default debootstrap mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ TO begin with:
 
 `make kernel_inject` Injects a newly built kernel into a previously build PrawnOS.img located in the root of the checkout
 
+You can use the environment variable `PRAWNOS_DEBOOTSTRAP_MIRROR` to use a non-default Debian mirror with debootstrap.  For example, to use [Debian's Tor onion service mirror](https://onion.debian.org/) with debootstrap, you can build with `sudo PRAWNOS_DEBOOTSTRAP_MIRROR=http://vwakviie2ienjx6t.onion/debian make image`.
+
 
 ### GPU Support
 

--- a/scripts/buildDebianFs.sh
+++ b/scripts/buildDebianFs.sh
@@ -78,9 +78,15 @@ create_image() {
 # create a 2GB image with the Chrome OS partition layout
 create_image PrawnOS-Alpha-c201-libre-2GB.img $outdev 50M 40 $outmnt
 
+# use default debootstrap mirror if none is specified
+if [ "$PRAWNOS_DEBOOTSTRAP_MIRROR" = "" ]
+then
+    PRAWNOS_DEBOOTSTRAP_MIRROR=http://ftp.us.debian.org/debian
+fi
+
 # install Debian on it
 export DEBIAN_FRONTEND=noninteractive
-qemu-debootstrap --arch armhf stretch --include locales,init --keyring=$build_resources/debian-archive-keyring.gpg $outmnt http://ftp.us.debian.org/debian
+qemu-debootstrap --arch armhf stretch --include locales,init --keyring=$build_resources/debian-archive-keyring.gpg $outmnt $PRAWNOS_DEBOOTSTRAP_MIRROR
 chroot $outmnt passwd -d root
 
 


### PR DESCRIPTION
This PR enables non-default debootstrap mirrors to be used via setting an environment variable.  My personal use case is that I'm building PrawnOS in a Whonix VM, and Tor onion services tend to be much more resilient against intermittent network errors than Tor exit relays are.  But I assume other people may have other reasons for wanting this, e.g. if they live geographically closer to a different mirror than PrawnOS uses by default.