### PR TITLE
Explicitly download sudo package

### DIFF
--- a/scripts/buildDebianFs.sh
+++ b/scripts/buildDebianFs.sh
@@ -109,7 +109,7 @@ chroot $outmnt apt-get autoremove --purge
 chroot $outmnt apt-get clean
 
 #Download the packages to be installed by Install.sh:
-chroot $outmnt apt-get install -y -d xorg acpi-support lightdm tasksel dpkg librsvg2-common xorg xserver-xorg-input-libinput alsa-utils anacron avahi-daemon eject iw libnss-mdns xdg-utils lxqt crda xfce4 dbus-user-session system-config-printer tango-icon-theme xfce4-power-manager xfce4-terminal xfce4-goodies mousepad vlc libutempter0 xterm numix-gtk-theme dconf-cli dconf-editor plank network-manager-gnome network-manager-openvpn network-manager-openvpn-gnome dtrx emacs25 accountsservice firefox-esr
+chroot $outmnt apt-get install -y -d xorg acpi-support lightdm tasksel dpkg librsvg2-common xorg xserver-xorg-input-libinput alsa-utils anacron avahi-daemon eject iw libnss-mdns xdg-utils lxqt crda xfce4 dbus-user-session system-config-printer tango-icon-theme xfce4-power-manager xfce4-terminal xfce4-goodies mousepad vlc libutempter0 xterm numix-gtk-theme dconf-cli dconf-editor plank network-manager-gnome network-manager-openvpn network-manager-openvpn-gnome dtrx emacs25 accountsservice firefox-esr sudo
 
 #Download support for libinput-gestures
 chroot $outmnt apt install -y libinput-tools xdotool build-essential


### PR DESCRIPTION
On Debian Buster and higher, `sudo` is no longer in the dependencies of the packages downloaded on the build machine, which causes a missing package error when `InstallPackages.sh` is run on the C201 (unless WiFi has already been manually enabled).  This PR fixes that issue by adding `sudo` explicitly to the list of downloaded packages.  It has no effect for Stretch.