### PR TITLE
Try Buster fstrim path if Stretch path not found

### DIFF
--- a/scripts/InstallScripts/InstallPackages.sh
+++ b/scripts/InstallScripts/InstallPackages.sh
@@ -101,7 +101,7 @@ cp -rf $DIR/30-touchpad.conf /etc/X11/xorg.conf.d/
 apt clean && apt autoremove --purge
 
 #enable periodic TRIM
-cp /usr/share/doc/util-linux/examples/fstrim.{service,timer} /etc/systemd/system
+cp /usr/share/doc/util-linux/examples/fstrim.{service,timer} /etc/systemd/system || cp /lib/systemd/system/fstrim.{service,timer} /etc/systemd/system
 systemctl enable fstrim.timer
 
 dmesg -D


### PR DESCRIPTION
Debian Buster and higher store the `fstrim` service files in a different path from Stretch, which causes a missing file error in `InstallPackages.sh`.  This PR fixes the issue by trying both paths and only erroring if they both weren't found.