### PR TITLE
Improve error handling when building

### DIFF
--- a/makefile
+++ b/makefile
@@ -68,11 +68,11 @@ clean_initramfs:
 
 .PHONY: clean_all
 clean_all:
-	make clean_kernel
-	make clean_ath
-	make clean_img
-	make clean_basefs
-	make clean_initramfs
+	$(MAKE) clean_kernel
+	$(MAKE) clean_ath
+	$(MAKE) clean_img
+	$(MAKE) clean_basefs
+	$(MAKE) clean_initramfs
 
 .PHONY: build_dirs
 build_dirs:
@@ -80,20 +80,20 @@ build_dirs:
 
 .PHONY: kernel
 kernel:
-	make build_dirs
+	$(MAKE) build_dirs
 	rm -rf build/logs/kernel-log.txt
 	bash -x scripts/buildKernel.sh $(KVER) 2>&1 | tee build/logs/kernel-log.txt
 
 .PHONY: initramfs
 initramfs:
-	make build_dirs
+	$(MAKE) build_dirs
 	rm -rf build/logs/kernel-log.txt
 	 bash -x scripts/buildInitramFs.sh $(BASE) 2>&1 | tee build/logs/initramfs-log.txt
 
 #makes the base filesystem image, no kernel only if the base image isnt present
 .PHONY: filesystem
 filesystem:
-	make build_dirs
+	$(MAKE) build_dirs
 	rm -rf build/logs/kernel-log.txt
 	[ -f $(BASE) ] || bash -x scripts/buildFilesystem.sh $(KVER) $(DEBIAN_SUITE) $(BASE) 2>&1 | tee build/logs/fs-log.txt
 
@@ -103,25 +103,25 @@ kernel_inject: #Targets an already built .img and swaps the old kernel with the 
 
 .PHONY: kernel_update
 kernel_update:
-	make initramfs
-	make kernel
-	make kernel_inject
+	$(MAKE) initramfs
+	$(MAKE) kernel
+	$(MAKE) kernel_inject
 
 .PHONY: injected_image
 injected_image: #makes a copy of the base image with a new injected kernel
-	make kernel
+	$(MAKE) kernel
 	cp $(BASE) $(OUTNAME)
-	make kernel_inject
+	$(MAKE) kernel_inject
 
 .PHONY: image
 image:
-	make clean_img
-	make filesystem
-	make initramfs
-	make kernel
+	$(MAKE) clean_img
+	$(MAKE) filesystem
+	$(MAKE) initramfs
+	$(MAKE) kernel
 #Make a new copy of the filesystem image
 	cp $(BASE) $(OUTNAME)
-	make kernel_inject
+	$MAKE) kernel_inject
 
 .PHONY: live_image
 live_image:

--- a/scripts/buildFilesystem.sh
+++ b/scripts/buildFilesystem.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -xe
+#!/bin/bash
+
+set -x
+set -e
 
 # Build fs, image
 

--- a/scripts/buildInitramFs.sh
+++ b/scripts/buildInitramFs.sh
@@ -1,4 +1,7 @@
-#!/bin/sh -xe
+#!/bin/bash
+
+set -x
+set -e
 
 #Build initramfs image
 

--- a/scripts/buildKernel.sh
+++ b/scripts/buildKernel.sh
@@ -1,4 +1,7 @@
-#!/bin/sh -xe
+#!/bin/bash
+
+set -x
+set -e
 
 #Build kenerl, wifi firmware
 

--- a/scripts/crossmenuconfig.sh
+++ b/scripts/crossmenuconfig.sh
@@ -1,4 +1,7 @@
-#!/bin/sh -xe
+#!/bin/bash
+
+set -x
+set -e
 
 #Runs Make menuconfig with the proper enviroment vars for cross compiling arm 
 #Grabs the file named config in resources/BuildResources directory, and updates it

--- a/scripts/injectKernelIntoFS.sh
+++ b/scripts/injectKernelIntoFS.sh
@@ -1,4 +1,7 @@
-#!/bin/sh -xe
+#!/bin/bash
+
+set -x
+set -e
 
 # This file is part of PrawnOS (http://www.prawnos.com)
 # Copyright (c) 2018 Hal Emmerich <hal@halemmerich.com>

--- a/scripts/patchKernel.sh
+++ b/scripts/patchKernel.sh
@@ -1,4 +1,7 @@
-#!/bin/sh -xe
+#!/bin/bash
+
+set -x
+set -e
 
 if [ -z "$1" ]
 then


### PR DESCRIPTION
Hi there,

First, thanks for the awesome project! I'd been trying for months to get my c201p on to either debian or arch and could never get it to work. PrawnOS took 5 minutes. Awesome.

Anyway, I started looking at some open issues and was working on setting up CI/CD with TravisCI/CircleCI. While working on the configuration, I noticed that it make failed, it kept going, without giving `-k`. I'm not intimately familiar with make syntax, but when looking at other projects, noticed the make/$(MAKE) difference, which fixes it.

Additionally, because the shell scripts were called as `bash -x foo`, their shebangs are overridden, so the `-e` was lost:
```
austin@laptop ~ $ cat foo.sh 
#!/bin/bash -xe
false
true
austin@laptop ~ $ ./foo.sh 
+ false
austin@laptop ~ $ bash -x ./foo.sh 
+ false
+ true
austin@laptop ~ $ bash -xe ./foo.sh 
+ false
austin@laptop ~ $ bash ./foo.sh 
austin@laptop ~ $ echo $?
0
```

So I moved the set inside the shell script. Additionally, I set them all to bash for consistency.

With these changes in place, make now properly fails earlier, i.e., when it first sees a problem.