### PR TITLE
Add missing ( on line 124

### DIFF
--- a/makefile
+++ b/makefile
@@ -121,7 +121,7 @@ image:
 	$(MAKE) kernel
 #Make a new copy of the filesystem image
 	cp $(BASE) $(OUTNAME)
-	$MAKE) kernel_inject
+	$(MAKE) kernel_inject
 
 .PHONY: live_image
 live_image:


### PR DESCRIPTION
Encountered an error building PrawnOS at the end when it injects the kernel, caused by a missing ( character. 