### PR TITLE
add github action for building image

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,21 @@
+# FIXME: currently just builds it, eventually, should use qemu to try to run
+# the image (potentially as a separate action)
+name: build-prawnos-image
+
+on: [push]
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout project
+        uses: actions/checkout@master
+      - name: build image
+        run: docker run --mount type=bind,source=$PWD,target=/PrawnOS
+             --privileged=true -v/dev:/dev debian:buster
+             /bin/bash /PrawnOS/tests/build-image.sh "$GITHUB_SHA"
+      - name: publish image
+        uses: actions/upload-artifact@v2
+        with:
+          name: image
+          path: "PrawnOS-Shiba-c201-git-*.img"

--- a/tests/build-image.sh
+++ b/tests/build-image.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This file is part of PrawnOS (http://www.prawnos.com)
+# Copyright (c) 2020 Austin English <austinenglish@gmail.com>
+
+# PrawnOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2
+# as published by the Free Software Foundation.
+
+# PrawnOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with PrawnOS.  If not, see <https://www.gnu.org/licenses/>.
+
+set -e
+set -x
+
+GITHUB_SHA="$1"
+
+cd "$(dirname "$0")/.."
+
+# Get dependencies listed in README.md:
+apt-get update
+apt-get -y install --no-install-recommends --no-install-suggests bc binfmt-support bison cgpt cmake debootstrap device-tree-compiler flex g++ gawk gcc gcc-arm-none-eabi git libc-dev libncurses-dev libssl-dev lzip make parted patch qemu-user-static texinfo u-boot-tools vboot-kernel-utils wget
+
+# And install stuff that is missing from the Debian/buster container:
+apt-get -y install --no-install-recommends --no-install-suggests bzip2 ca-certificates cpio file gpg gpg-agent kmod udev
+
+# Note: there's an error for /proc/modules, but at least building the image works fine:
+# libkmod: ERROR ../libkmod/libkmod-module.c:1657 kmod_module_new_from_loaded: could not open /proc/modules: No such file or directory
+make image
+
+# rename the image to include git sha:
+mv PrawnOS-Shiba-c201.img "PrawnOS-Shiba-c201-git-${GITHUB_SHA}.img"


### PR DESCRIPTION
This is an initial step towards fixing #150.

Note that this only builds the image, it doesn't (yet) test it. I haven't used qemu with arm before, so I've got some learning to do before attempting that. Still, this is useful to show to:
A) show that a PR won't break the build
B) allow downloading a snapshot image without having to setup a build environment

an example build/image can be seen here:
https://github.com/austin987/PrawnOS/actions/runs/106910960

note that this depends on #156 and #158 being merged so that the build will actually work.

Some minor notes: some more packages that weren't listed in the README dependencies are needed (at least, for building in a container, they may be in a base debian install, didn't verify). Perhaps instead we should add those packages to the README list instead of keeping it separate.

If this approach is acceptable, it may also be worth expanding it a bit to try building against different debian suites (i.e., run multiple pipelines against stretch/buster/etc.) to catch potential problems before they happen. Anyway, wanted to get the initial work in before expanding on it ;).

FYI, the image created does work, I just reimaged my C201P and the kernels is 5.4.29, not 5.4.23 which is what's in the last official release :) 