### PR TITLE
README.md: mention submodules when cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ These packages are required:
 ```
 
 ## Build
-Clone this Git repo. 
+Clone this Git repo: `git clone --recurse-submodules https://github.com/SolidHal/PrawnOS`
 
 Build the `PrawnOS-*-.img` by running `sudo make image`
 


### PR DESCRIPTION
Helps avoid:
```
austin@laptop ~/src/PrawnOS (clone) $ git commit .
error: 'resources/InstallResources/fonts/source-code-pro' does not have a commit checked out
fatal: updating files failed
```