### PR TITLE
dmks support and kernel headers integrated to image

### DIFF
--- a/scripts/BuildScripts/ImageScripts/installKernelToFs.sh
+++ b/scripts/BuildScripts/ImageScripts/installKernelToFs.sh
@@ -69,7 +69,7 @@ dd if=/dev/zero of=${outdev}p1 conv=notrunc bs=512 count=$kernel_size
 #now write the new kernel
 dd if=build/linux-$KVER/vmlinux.kpart of=${outdev}p1 conv=notrunc
 make -C build/linux-$KVER ARCH=arm INSTALL_MOD_PATH=$outmnt modules_install
-
+make -C build/linux-$KVER ARCH=arm INSTALL_HDR_PATH=$outmnt/usr/src/linux-$KVER-gnu headers_install
 # the ath9k firmware is built into the kernel image, so nothing else must be done
 
 umount -l $outmnt > /dev/null 2>&1

--- a/scripts/Shared/package_lists.sh
+++ b/scripts/Shared/package_lists.sh
@@ -80,6 +80,7 @@ base_debs_download=(
     crda
     dbus-user-session
     dpkg
+    dkms
     dtrx
     eject
     emacs


### PR DESCRIPTION
dkms complains about not finding an initramfs image it can modify but the solution is good enough for simple modules that are not needed at boottime