### PR TITLE
Very small fix to panfrost compile

### DIFF
--- a/scripts/InstallScripts/CompilePanfrost.sh
+++ b/scripts/InstallScripts/CompilePanfrost.sh
@@ -9,7 +9,7 @@ cd /tmp || exit 1
 git clone https://gitlab.freedesktop.org/mesa/mesa -b 20.2
 mkdir -p mesa/build
 cd mesa/build || exit 1
-meson .. . -Dprefix=/usr -Ddri-drivers= -Dvulkan-drivers= -Dgallium-drivers=panfrost,kmsro,swrast -Dlibunwind=false
+meson .. . -Dprefix=/opt -Ddri-drivers= -Dvulkan-drivers= -Dgallium-drivers=panfrost,kmsro -Dlibunwind=false
 sudo ninja install
 
 echo "You may now reboot"


### PR DESCRIPTION
CompilePanfrost.sh works very good on latest PrawnOS and 20.2 branch - tested on minnie. Thanks to @Maccraft123 i fixed my issue with the libs confusing debians shipped libs - each time you install software you need to reinstall panfrost or QT5-apps wont work (segfaults).

Moving the install to /opt fixes that.