### PR TITLE
.github/workflows: fix github sha variable expansion

### DIFF
--- a/.github/workflows/build-image-arm64.yml
+++ b/.github/workflows/build-image-arm64.yml
@@ -17,5 +17,5 @@ jobs:
       - name: publish image
         uses: actions/upload-artifact@v2
         with:
-          name: "PrawnOS-Shiba-arm64-git-${GITHUB_SHA}.img.xz"
-          path: "PrawnOS-Shiba-arm64-git-${GITHUB_SHA}.img.xz"
+          name: "PrawnOS-Shiba-arm64-git-${{ github.sha }}.img.xz"
+          path: "PrawnOS-Shiba-arm64-git-${{ github.sha }}.img.xz"

--- a/.github/workflows/build-image-armhf.yml
+++ b/.github/workflows/build-image-armhf.yml
@@ -17,5 +17,5 @@ jobs:
       - name: publish image
         uses: actions/upload-artifact@v2
         with:
-          name: "PrawnOS-Shiba-armhf-git-${GITHUB_SHA}.img.xz"
-          path: "PrawnOS-Shiba-armhf-git-${GITHUB_SHA}.img.xz"
+          name: "PrawnOS-Shiba-armhf-git-${{ github.sha }}.img.xz"
+          path: "PrawnOS-Shiba-armhf-git-${{ github.sha }}.img.xz"


### PR DESCRIPTION
Recent builds don't have artifacts available, see, e.g., https://github.com/SolidHal/PrawnOS/actions/runs/305642680

I sometimes use github to build images when I'm lazy and don't want to tie up my own machine, so I had motivation to fix it :).

Example: https://github.com/austin987/PrawnOS/actions/runs/306511059

@SolidHal 