### PR TITLE
scripts/BuildScripts/BuildCommon.mk: unique names for development images

### DIFF
--- a/scripts/BuildScripts/BuildCommon.mk
+++ b/scripts/BuildScripts/BuildCommon.mk
@@ -103,8 +103,15 @@ PRAWNOS_SUITE := Shiba
 endif
 
 PRAWNOS_GIT_SHA := $(shell git rev-parse HEAD)
+PRAWNOS_GIT_BRANCH := $(shell git branch --show-current)
 
+# If we're not on masteer, append the branch name/sha1 to the imagename
+ifeq ($(PRAWNOS_GIT_BRANCH),master)
 PRAWNOS_IMAGE := $(PRAWNOS_ROOT)/PrawnOS-$(PRAWNOS_SUITE)-$(TARGET).img
+else
+PRAWNOS_IMAGE := $(PRAWNOS_ROOT)/PrawnOS-$(PRAWNOS_SUITE)-$(TARGET)-git-$(PRAWNOS_GIT_BRANCH)-$(PRAWNOS_GIT_SHA).img
+endif
+
 PRAWNOS_IMAGE_GIT := $(PRAWNOS_ROOT)/PrawnOS-$(PRAWNOS_SUITE)-$(TARGET)-git-$(PRAWNOS_GIT_SHA).img
 PRAWNOS_IMAGE_GIT_GZ := $(PRAWNOS_IMAGE_GIT).gz
 PRAWNOS_IMAGE_BASE := $(PRAWNOS_IMAGE)-BASE


### PR DESCRIPTION
For your consideration.

I often have a few branches in play, and end up manually renaming images when testing something. Got tired of that, came up with this, figured I'd upstream it. If not interested, no worries, I'll maintain it locally.