### PR TITLE
Add initial support for Veyron-Mickey (Asus Chromebit CS10)

### DIFF
--- a/filesystem/resources/console-font.sh
+++ b/filesystem/resources/console-font.sh
@@ -20,6 +20,7 @@
 
 device_veyron_speedy="Google Speedy"
 device_veyron_minnie="Google Minnie"
+device_veyron_mickey="Google Mickey"
 device_gru_kevin="Google Kevin"
 device_gru_bob="Google Bob"
 

--- a/kernel/resources/armhf/kernel.its
+++ b/kernel/resources/armhf/kernel.its
@@ -37,6 +37,17 @@
 				algo = "sha1";
 			};
 		};
+		fdt@3 {
+                        description = "dtb";
+                        data = /incbin/("arch/arm/boot/dts/rk3288-veyron-mickey.dtb");
+                        type = "flat_dt";
+                        arch = "arm";
+                        compression = "none";
+                        hash {
+                                algo = "sha1";
+                        };
+                };
+
 	};
 	configurations {
 		default = "conf@1";
@@ -48,5 +59,10 @@
 			kernel = "kernel@1";
 			fdt = "fdt@2";
 		};
+                conf@3{
+                        kernel = "kernel@1";
+                        fdt = "fdt@3";
+                };
+
 	};
 };

--- a/kernel/resources/shared/FlashKernelPartition.sh
+++ b/kernel/resources/shared/FlashKernelPartition.sh
@@ -23,6 +23,7 @@
 ### SHARED CONST AND VARS
 device_veyron_speedy="Google Speedy"
 device_veyron_minnie="Google Minnie"
+device_veyron_mickey="Google Mickey"
 device_gru_kevin="Google Kevin"
 device_gru_bob="Google Bob"
 
@@ -36,6 +37,7 @@ get_emmc_devname() {
     case "$device" in
         $device_veyron_speedy) local devname=mmcblk2;;
         $device_veyron_minnie) local devname=mmcblk2;;
+	$device_veyron_mickey) local devname=mmcblk2;;
         $device_gru_kevin) local devname=mmcblk0;;
         $device_gru_bob) local devname=mmcblk0;;
         * ) echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;
@@ -49,6 +51,7 @@ get_sd_devname() {
     case "$device" in
         $device_veyron_speedy) local devname=mmcblk0;;
         $device_veyron_minnie) local devname=mmcblk0;;
+	$device_veyron_mickey) local devname=mmcblk0;;
         $device_gru_kevin) local devname=mmcblk1;;
         $device_gru_bob) local devname=mmcblk1;;
         * ) echo "Unknown device! can't determine sd card devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;

--- a/scripts/InstallScripts/InstallPackages.sh
+++ b/scripts/InstallScripts/InstallPackages.sh
@@ -24,6 +24,7 @@ SCRIPTS=/etc/prawnos/install/scripts
 # TODO: when these scripts are packaged, place these in a shared script instead of in every file that needs them
 device_veyron_speedy="Google Speedy"
 device_veyron_minnie="Google Minnie"
+device_veyron_mickey="Google Mickey"
 device_gru_kevin="Google Kevin"
 device_gru_bob="Google Bob"
 
@@ -37,6 +38,7 @@ get_emmc_devname() {
     case "$device" in
         $device_veyron_speedy) local devname=mmcblk2;;
         $device_veyron_minnie) local devname=mmcblk2;;
+	$device_veyron_mickey) local devname=mmcblk2;;
         $device_gru_kevin) local devname=mmcblk1;;
         $device_gru_bob) local devname=mmcblk1;;
         * ) echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;
@@ -50,6 +52,7 @@ get_sd_devname() {
     case "$device" in
         $device_veyron_speedy) local devname=mmcblk0;;
         $device_veyron_minnie) local devname=mmcblk0;;
+	$device_veyron_mickey) local devname=mmcblk0;;
         $device_gru_kevin) local devname=mmcblk0;;
         $device_gru_bob) local devname=mmcblk0;;
         * ) echo "Unknown device! can't determine sd card devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;

--- a/scripts/InstallScripts/InstallPrawnOS.sh
+++ b/scripts/InstallScripts/InstallPrawnOS.sh
@@ -27,6 +27,7 @@ SCRIPTS=/etc/prawnos/install/scripts
 # TODO: when these scripts are packaged, place these in a shared script instead of in every file that needs them
 device_veyron_speedy="Google Speedy"
 device_veyron_minnie="Google Minnie"
+device_veyron_mickey="Google Mickey"
 device_gru_kevin="Google Kevin"
 device_gru_bob="Google Bob"
 
@@ -40,6 +41,7 @@ get_emmc_devname() {
     case "$device" in
         $device_veyron_speedy) local devname=mmcblk2;;
         $device_veyron_minnie) local devname=mmcblk2;;
+	$device_veyron_mickey) local devname=mmcblk2;;
         $device_gru_kevin) local devname=mmcblk1;;
         $device_gru_bob) local devname=mmcblk1;;
         * ) echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;
@@ -53,6 +55,7 @@ get_sd_devname() {
     case "$device" in
         $device_veyron_speedy) local devname=mmcblk0;;
         $device_veyron_minnie) local devname=mmcblk0;;
+	$device_veyron_mickey) local devname=mmcblk0;;
         $device_gru_kevin) local devname=mmcblk0;;
         $device_gru_bob) local devname=mmcblk0;;
         * ) echo "Unknown device! can't determine sd card devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;


### PR DESCRIPTION
This adds initial support for veyron-mickey ([Asus Chromebit CS10](https://www.asus.com/us/Mini-PCs/Chromebit-CS10/)). It boots and I was able to install GNOME 3; I'm submitting this pull request from it!

The Chromebit is basically a stick with HDMI at one end and a USB port at the other. As it does not have a headphone jack, speakers, trackpad, or screen.. I did not include it in the DEVICE SPECIFIC CONFIG section of InstallPackages.sh and so far things seem to work, including the HDMI audio!

![Screenshot from 2020-12-11 02-40-55](https://user-images.githubusercontent.com/33880035/101884075-0fb85480-3b90-11eb-9736-9f58d37e7628.png)
