### PR TITLE
Fix emmc values for veyron-mickey in install scripts

### DIFF
--- a/scripts/InstallScripts/InstallPackages.sh
+++ b/scripts/InstallScripts/InstallPackages.sh
@@ -38,7 +38,7 @@ get_emmc_devname() {
     case "$device" in
         $device_veyron_speedy) local devname=mmcblk2;;
         $device_veyron_minnie) local devname=mmcblk2;;
-	$device_veyron_mickey) local devname=mmcblk2;;
+        $device_veyron_mickey) local devname=mmcblk1;;
         $device_gru_kevin) local devname=mmcblk1;;
         $device_gru_bob) local devname=mmcblk1;;
         * ) echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;
@@ -52,7 +52,7 @@ get_sd_devname() {
     case "$device" in
         $device_veyron_speedy) local devname=mmcblk0;;
         $device_veyron_minnie) local devname=mmcblk0;;
-	$device_veyron_mickey) local devname=mmcblk0;;
+        $device_veyron_mickey) local devname=mmcblk0;;
         $device_gru_kevin) local devname=mmcblk0;;
         $device_gru_bob) local devname=mmcblk0;;
         * ) echo "Unknown device! can't determine sd card devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;

--- a/scripts/InstallScripts/InstallPrawnOS.sh
+++ b/scripts/InstallScripts/InstallPrawnOS.sh
@@ -41,7 +41,7 @@ get_emmc_devname() {
     case "$device" in
         $device_veyron_speedy) local devname=mmcblk2;;
         $device_veyron_minnie) local devname=mmcblk2;;
-	$device_veyron_mickey) local devname=mmcblk2;;
+        $device_veyron_mickey) local devname=mmcblk1;;
         $device_gru_kevin) local devname=mmcblk1;;
         $device_gru_bob) local devname=mmcblk1;;
         * ) echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;
@@ -55,7 +55,7 @@ get_sd_devname() {
     case "$device" in
         $device_veyron_speedy) local devname=mmcblk0;;
         $device_veyron_minnie) local devname=mmcblk0;;
-	$device_veyron_mickey) local devname=mmcblk0;;
+        $device_veyron_mickey) local devname=mmcblk0;;
         $device_gru_kevin) local devname=mmcblk0;;
         $device_gru_bob) local devname=mmcblk0;;
         * ) echo "Unknown device! can't determine sd card devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;


### PR DESCRIPTION
@rk-zero noted the value for the emmc on veyron-mickey was mmcblk1, unlike other veyron devices (so far) which is mmcblk2. This pull request changes the emmc value for veyron-mickey in InstallPrawnOS.sh and InstallPackages.sh to reflect mmcblk1. 

Also double checked the output of fdisk -l on the cs10 and c100, which both still have ChromeOS on the emmc and confirmed the mmcblk1 vs mmcblk2 values, respectively.  


**Veyron-Mickey / CS10:**
```
Disk /dev/mmcblk1: 14.68 GiB, 15758000128 bytes, 30777344 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: 2F8EA92F-45EF-C145-AE47-9B02F64B7DA2

Device            Start      End  Sectors  Size Type
/dev/mmcblk1p1  8671232 30744575 22073344 10.5G Microsoft basic data
/dev/mmcblk1p2    20480    53247    32768   16M ChromeOS kernel
/dev/mmcblk1p3  4476928  8671231  4194304    2G ChromeOS root fs
/dev/mmcblk1p4    53248    86015    32768   16M ChromeOS kernel
/dev/mmcblk1p5   282624  4476927  4194304    2G ChromeOS root fs
/dev/mmcblk1p6    16448    16448        1  512B ChromeOS kernel
/dev/mmcblk1p7    16449    16449        1  512B ChromeOS root fs
/dev/mmcblk1p8    86016   118783    32768   16M Microsoft basic data
/dev/mmcblk1p9    16450    16450        1  512B ChromeOS reserved
/dev/mmcblk1p10   16451    16451        1  512B ChromeOS reserved
/dev/mmcblk1p11      64    16447    16384    8M unknown
/dev/mmcblk1p12  249856   282623    32768   16M EFI System

Partition table entries are not in disk order.
```

**Veyron-Minnie / C100:**
```
Disk /dev/mmcblk2: 14.68 GiB, 15758000128 bytes, 30777344 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: 0EB81705-DC06-0248-9D7E-A478985ABC49

Device            Start      End  Sectors  Size Type
/dev/mmcblk2p1  8671232 30744575 22073344 10.5G Microsoft basic data
/dev/mmcblk2p2    20480    53247    32768   16M ChromeOS kernel
/dev/mmcblk2p3  4476928  8671231  4194304    2G ChromeOS root fs
/dev/mmcblk2p4    53248    86015    32768   16M ChromeOS kernel
/dev/mmcblk2p5   282624  4476927  4194304    2G ChromeOS root fs
/dev/mmcblk2p6    16448    16448        1  512B ChromeOS kernel
/dev/mmcblk2p7    16449    16449        1  512B ChromeOS root fs
/dev/mmcblk2p8    86016   118783    32768   16M Microsoft basic data
/dev/mmcblk2p9    16450    16450        1  512B ChromeOS reserved
/dev/mmcblk2p10   16451    16451        1  512B ChromeOS reserved
/dev/mmcblk2p11      64    16447    16384    8M unknown
/dev/mmcblk2p12  249856   282623    32768   16M EFI System

Partition table entries are not in disk order.
```