### PR TITLE
misc shellcheck fixes

### DIFF
--- a/filesystem/resources/pbuilder/hooks/D60no-man-db-rebuild
+++ b/filesystem/resources/pbuilder/hooks/D60no-man-db-rebuild
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Don't rebuild man-db
 
 echo "I: Preseed man-db/auto-update to false"

--- a/filesystem/resources/pbuilder/hooks/D70update
+++ b/filesystem/resources/pbuilder/hooks/D70update
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/bin/bash
 /usr/bin/apt-get update

--- a/initramfs/resources/initramfs-init
+++ b/initramfs/resources/initramfs-init
@@ -1,4 +1,10 @@
 #!/bin/busybox sh
+# shellcheck shell=sh
+# shellcheck disable=SC2039
+#
+# Really, this should be ash, not sh, but shellcheck doesn't support ash, see
+# https://github.com/koalaman/shellcheck/issues/853
+# SC2039 is there because of that (local/== unsupported in sh, work in ash)
 
 # This is the init script built into the PrawnOS initramfs
 
@@ -21,8 +27,8 @@ echo In PrawnOS Init
 
 #add this to start shell at desired point
 rescue_shell() {
-    [ "{$1}" != "debug" ] && echo "Something went wrong. Dropping to a shell." > /dev/tty1
-    [ "{$1}" == "debug" ] && echo "Debug flag detected, entering debug shell" > /dev/tty1
+    [ "${1}" != "debug" ] && echo "Something went wrong. Dropping to a shell." > /dev/tty1
+    [ "${1}" == "debug" ] && echo "Debug flag detected, entering debug shell" > /dev/tty1
     echo "Something went wrong. Dropping to a shell." > /dev/tty1
     exec setsid /bin/sh -c 'exec /bin/sh </dev/tty1 >/dev/tty1 2>&1'
 }
@@ -53,10 +59,12 @@ rootpartuuid() {
 # if optional count is provided:
 # returns 1 if substring occurs in string < optional count
 # returns 0 otherwise
-occur() while case "$1" in (*"$2"*) set -- \
+occur() {
+    while case "$1" in (*"$2"*) set -- \
         "${1#*"$2"}" "$2" "${3:-0}" "$((${4:-0}+1))";;
         (*) return "$((${4:-0}<${3:-1}))";;esac
         do : "${_occur:+$((_occur=$4))}";done
+}
 
 # mount the bare necesities
 mount -n -t proc     proc      /proc
@@ -93,22 +101,20 @@ fi
 
 echo BLKID: ${BLKID} > /dev/tty1
 
-#If its an mmcblk device, the kernel partiton will p1. If it is a usb device, the partiton will just be 1
-#Just want everything before the 1
+# If it's an mmcblk device, the kernel partiton will be p1. If it is a usb device, the partiton will just be 1.
+# Just want everything before the 1
 ROOT_DEV="${BLKID%1:*}"
 echo ROOT_DEV: ${ROOT_DEV} > /dev/tty1
 
 # label any partition on the system with RESCUESHELL to enter the initramfs rescue shell before mount and root_switch.
 # you can do this with "cgpt add -i 1 -l RESCUESHELL /dev/sda" for example to label the first partiton of a usb drive.
-if [ -n "$(blkid | grep RESCUESHELL)" ]
-then
+if blkid | grep -q RESCUESHELL; then
     rescue_shell debug
 fi
 
 
-if [ -n "$(blkid ${ROOT_DEV}2 | grep crypto_LUKS)" ]
-then
-    #decrypt and mount the root filesystem, disable kernel log messages to avoid clashing with the prompt
+if blkid ${ROOT_DEV}2 | grep -q crypto_LUKS; then
+    # decrypt and mount the root filesystem, disable kernel log messages to avoid clashing with the prompt
     dmesg -n 2
     echo "Opening encrypted root partition, this will take 30s..."
     cryptsetup --tries 5 luksOpen ${ROOT_DEV}2 luksroot || rescue_shell

--- a/scripts/InstallScripts/InstallPackages.sh
+++ b/scripts/InstallScripts/InstallPackages.sh
@@ -1,5 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 
+set -e
 
 # This file is part of PrawnOS (https://www.prawnos.com)
 # Copyright (c) 2018 Hal Emmerich <hal@halemmerich.com>

--- a/scripts/InstallScripts/InstallPrawnOS.sh
+++ b/scripts/InstallScripts/InstallPrawnOS.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -e
 
 #See the block of "echos" in main() for description of this script
 


### PR DESCRIPTION
The /bin/sh -> /bin/bash was for consistency with the rest of PrawnOS. If there's a strong reason for them to be /bin/sh, they can stay that way.