### PR TITLE
Fix syntax in InstallPackages.sh and InstallPrawnOS.sh

### DIFF
--- a/scripts/InstallScripts/InstallPackages.sh
+++ b/scripts/InstallScripts/InstallPackages.sh
@@ -37,7 +37,8 @@ get_emmc_devname() {
     local devname=$(ls /dev/mmcblk* | grep -F boot0 | sed "s/boot0//")
     if [ -z "$devname" ]
     then
-        echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;
+        echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"
+        exit 1
     fi
     echo $devname
 }

--- a/scripts/InstallScripts/InstallPrawnOS.sh
+++ b/scripts/InstallScripts/InstallPrawnOS.sh
@@ -40,7 +40,8 @@ get_emmc_devname() {
     local devname=$(ls /dev/mmcblk* | grep -F boot0 | sed "s/boot0//")
     if [ -z "$devname" ]
     then
-        echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;
+        echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"
+        exit 1
     fi
     echo $devname
 }


### PR DESCRIPTION
Attempted to install PrawnOS from fresh build, received error: 
```
syntax error near unexpected token `;;'
```

Double semicolon was used outside a case construct. Removed double semicolons and moved "exit 1" to new line in both InstallPackages.sh and InstallPrawnOS.sh. 
