### PR TITLE
Fix syntax error from refactoring case statement

### DIFF
--- a/scripts/InstallScripts/InstallPrawnOS.sh
+++ b/scripts/InstallScripts/InstallPrawnOS.sh
@@ -42,7 +42,7 @@ get_emmc_devname() {
     then
         echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;
     fi
-    echo $devname
+    echo $(basename $devname)
 }
 
 

--- a/scripts/InstallScripts/InstallPrawnOS.sh
+++ b/scripts/InstallScripts/InstallPrawnOS.sh
@@ -40,7 +40,7 @@ get_emmc_devname() {
     local devname=$(ls /dev/mmcblk* | grep -F boot0 | sed "s/boot0//")
     if [ -z "$devname" ]
     then
-        echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;;
+        echo "Unknown device! can't determine emmc devname. Please file an issue with the output of fdisk -l if you get this on a supported device"; exit 1;
     fi
     echo $devname
 }


### PR DESCRIPTION
Fixing minor typo/bug that originated in https://github.com/SolidHal/PrawnOS/commit/0bd5575b0b84bcf469cd0b94351c10f1a0a459f9.

With this present, running `InstallPrawnOS` results in:
```/usr/bin/InstallPrawnOS: line 43: syntax error near unexpected token `;;'```

Just wanted to also thank you for your hard work with PrawnOS!