### PR TITLE
scripts/Shared/package_lists.sh: add gvfs-backends/gvfs-fuse to desktop packages

### DIFF
--- a/scripts/Shared/package_lists.sh
+++ b/scripts/Shared/package_lists.sh
@@ -87,6 +87,8 @@ base_debs_download=(
     dkms
     eject
     firefox-esr
+    gvfs-backends
+    gvfs-fuse
     iw
     libegl-mesa0
     libegl1-mesa


### PR DESCRIPTION
This allows mounting android phones for file sharing via fuse/thunar, for example.

Split out from #270