### PR TITLE
add ntp to package_lists.sh

### DIFF
--- a/scripts/Shared/package_lists.sh
+++ b/scripts/Shared/package_lists.sh
@@ -59,6 +59,7 @@ base_debs_install=(
     net-tools
     netcat-openbsd
     network-manager
+    ntp
     parted
     pciutils
     psmisc


### PR DESCRIPTION
had to install ntp post-install to fix date, couldn't apt update because certificate issues having to do with system time/date, fresh install rendered system's time as being March 2022 as of October 30th 2022